### PR TITLE
🐞 fix: Options Menu no longer Freezes the menu

### DIFF
--- a/src/lt/states/MenuState.hx
+++ b/src/lt/states/MenuState.hx
@@ -34,7 +34,7 @@ class MenuState extends StateBase {
 	var options(get, never):Array<Dynamic>;
 	function get_options():Array<Dynamic>{
 		return [
-			["options", () -> trace("wawer")],
+			["options", () -> Utils.switchState(new MenuState(), "Main Menu")],
 			["play", () -> Utils.switchState(new MenuDebugState(), "Song Select")],
 			["edit", () -> Utils.switchState(new LevelEditorState(), "Level Editor")]
 		];	


### PR DESCRIPTION
This makes it so that the options menu selection no longer freezes up the main menu