### PR TITLE
🐞 fix: Tutorial text on song Select is now lowercased

### DIFF
--- a/src/lt/states/MenuDebugState.hx
+++ b/src/lt/states/MenuDebugState.hx
@@ -16,7 +16,7 @@ class MenuDebugState extends State {
     var noType:Bool = false;
     var inputCaret:Sprite;
     var lastInvalidSong:String = "";
-    var song(default,set):String = "Tutorial";
+    var song(default,set):String = "tutorial";
     function set_song(val:String):String {
         if (inputText != null)
             inputText.text = val;


### PR DESCRIPTION
This PR turns "Tutorial" into "tutorial"